### PR TITLE
Return client error when database dir does not exist

### DIFF
--- a/deebee.go
+++ b/deebee.go
@@ -80,8 +80,8 @@ type Dir interface {
 	FileReader(name string) (io.ReadCloser, error)
 	// Creates a new file for write. Must return error when file already exists
 	FileWriter(name string) (FileWriter, error)
-	// Creates directory. Do nothing when directory already exists
-	Mkdir(name string) error // TODO Change with Mkdir()
+	// Creates this directory. Do nothing when directory already exists
+	Mkdir() error
 	// Return directory with name. Does not check immediately if dir exists.
 	Dir(name string) Dir
 	// Returns true when directory exists

--- a/deebee.go
+++ b/deebee.go
@@ -10,6 +10,14 @@ func Open(dir Dir, options ...Option) (*DB, error) {
 	if dir == nil {
 		return nil, errors.New("nil dir")
 	}
+	dirExists, err := dir.Exists()
+	if err != nil {
+		return nil, err
+	}
+	if !dirExists {
+		return nil, newClientError(fmt.Sprintf("database dir %s not found", dir))
+	}
+
 	newChecksum := func() Checksum {
 		return &zeroChecksum{}
 	}
@@ -72,12 +80,12 @@ type Dir interface {
 	FileReader(name string) (io.ReadCloser, error)
 	// Creates a new file for write. Must return error when file already exists
 	FileWriter(name string) (FileWriter, error)
-	// Returns true when directory exists
-	DirExists(name string) (bool, error)
 	// Creates directory. Do nothing when directory already exists
-	Mkdir(name string) error
-	// Return directory with name
+	Mkdir(name string) error // TODO Change with Mkdir()
+	// Return directory with name. Does not check immediately if dir exists.
 	Dir(name string) Dir
+	// Returns true when directory exists
+	Exists() (bool, error)
 	// List files excluding directories
 	ListFiles() ([]string, error)
 }

--- a/deebee_test.go
+++ b/deebee_test.go
@@ -19,27 +19,27 @@ func TestOpen(t *testing.T) {
 	})
 
 	t.Run("should open db with no options", func(t *testing.T) {
-		dir := &fake.Dir{}
+		dir := fake.ExistingDir()
 		db, err := deebee.Open(dir)
 		require.NoError(t, err)
 		assert.NotNil(t, db)
 	})
 
 	t.Run("should skip nil option", func(t *testing.T) {
-		dir := &fake.Dir{}
+		dir := fake.ExistingDir()
 		db, err := deebee.Open(dir, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, db)
 	})
 
 	t.Run("should return client error when database dir does not exist", func(t *testing.T) {
-		db, err := deebee.Open(missingDir())
+		db, err := deebee.Open(fake.MissingDir())
 		assert.True(t, deebee.IsClientError(err))
 		assert.Nil(t, db)
 	})
 
 	t.Run("should return error when option returned error", func(t *testing.T) {
-		dir := &fake.Dir{}
+		dir := fake.ExistingDir()
 		expectedError := &testError{}
 		option := func(state *deebee.DB) error {
 			return expectedError
@@ -64,7 +64,7 @@ func TestDB_NewReader(t *testing.T) {
 	t.Run("should return error for invalid keys", func(t *testing.T) {
 		for _, key := range invalidKeys {
 			t.Run(key, func(t *testing.T) {
-				db := openDB(t, &fake.Dir{})
+				db := openDB(t, fake.ExistingDir())
 				// when
 				reader, err := db.NewReader(key)
 				// then
@@ -75,7 +75,7 @@ func TestDB_NewReader(t *testing.T) {
 	})
 
 	t.Run("should return error when no data was previously saved", func(t *testing.T) {
-		db := openDB(t, &fake.Dir{})
+		db := openDB(t, fake.ExistingDir())
 		// when
 		reader, err := db.NewReader("state")
 		// then
@@ -85,17 +85,11 @@ func TestDB_NewReader(t *testing.T) {
 	})
 }
 
-func missingDir() deebee.Dir {
-	dir := &fake.Dir{}
-	missingDir := dir.Dir("missing")
-	return missingDir
-}
-
 func TestDB_NewWriter(t *testing.T) {
 	t.Run("should return error for invalid keys", func(t *testing.T) {
 		for _, key := range invalidKeys {
 			t.Run(key, func(t *testing.T) {
-				db := openDB(t, &fake.Dir{})
+				db := openDB(t, fake.ExistingDir())
 				// when
 				writer, err := db.NewWriter(key)
 				// then
@@ -116,7 +110,7 @@ func TestReadAfterWrite(t *testing.T) {
 		for name, data := range tests {
 
 			t.Run(name, func(t *testing.T) {
-				db := openDB(t, &fake.Dir{})
+				db := openDB(t, fake.ExistingDir())
 				writeData(t, db, "state", data)
 				// when
 				actual := readData(t, db, "state")

--- a/deebee_test.go
+++ b/deebee_test.go
@@ -33,7 +33,7 @@ func TestOpen(t *testing.T) {
 	})
 
 	t.Run("should return client error when database dir does not exist", func(t *testing.T) {
-		db, err := deebee.Open(notExistingDir())
+		db, err := deebee.Open(missingDir())
 		assert.True(t, deebee.IsClientError(err))
 		assert.Nil(t, db)
 	})
@@ -85,10 +85,10 @@ func TestDB_NewReader(t *testing.T) {
 	})
 }
 
-func notExistingDir() deebee.Dir {
+func missingDir() deebee.Dir {
 	dir := &fake.Dir{}
-	notExistingDir := dir.Dir("not-existing")
-	return notExistingDir
+	missingDir := dir.Dir("missing")
+	return missingDir
 }
 
 func TestDB_NewWriter(t *testing.T) {

--- a/fake/filesystem.go
+++ b/fake/filesystem.go
@@ -58,12 +58,8 @@ func (f *Dir) Files() []*File {
 	return slice
 }
 
-func (f *Dir) DirExists(name string) (bool, error) {
-	if f.dirs == nil {
-		return false, nil
-	}
-	_, exists := f.dirs[name]
-	return exists, nil
+func (f *Dir) Exists() (bool, error) {
+	return !f.doesNotExist, nil
 }
 
 func (f *Dir) Mkdir(name string) error {

--- a/fake/filesystem_test.go
+++ b/fake/filesystem_test.go
@@ -23,7 +23,7 @@ func rootDir(t *testing.T) deebee.Dir {
 
 func makeNestedDir(t *testing.T) deebee.Dir {
 	dir := &fake.Dir{}
-	err := dir.Mkdir("nested")
+	err := dir.Dir("nested").Mkdir()
 	require.NoError(t, err)
 	return dir.Dir("nested")
 }

--- a/fake/filesystem_test.go
+++ b/fake/filesystem_test.go
@@ -115,8 +115,8 @@ func TestFile_Read(t *testing.T) {
 	test.TestFileReader_Read(t, dirs)
 }
 
-func TestDir_DirExists(t *testing.T) {
-	test.TestDir_DirExists(t, dirs)
+func TestDir_Exists(t *testing.T) {
+	test.TestDir_Exists(t, dirs)
 }
 
 func TestDir_Mkdir(t *testing.T) {

--- a/fake/filesystem_test.go
+++ b/fake/filesystem_test.go
@@ -13,16 +13,24 @@ import (
 const fileName = "test"
 
 var dirs = map[string]test.NewDir{
-	"root":   rootDir,
-	"nested": makeNestedDir,
+	"existing root": existingRootDir,
+	"created root":  makeRootDir,
+	"nested":        makeNestedDir,
 }
 
-func rootDir(t *testing.T) deebee.Dir {
-	return &fake.Dir{}
+func existingRootDir(t *testing.T) deebee.Dir {
+	return fake.ExistingDir()
+}
+
+func makeRootDir(t *testing.T) deebee.Dir {
+	dir := fake.MissingDir()
+	err := dir.Mkdir()
+	require.NoError(t, err)
+	return dir
 }
 
 func makeNestedDir(t *testing.T) deebee.Dir {
-	dir := &fake.Dir{}
+	dir := fake.ExistingDir()
 	err := dir.Dir("nested").Mkdir()
 	require.NoError(t, err)
 	return dir.Dir("nested")
@@ -34,14 +42,14 @@ func TestDir_FileWriter(t *testing.T) {
 
 func TestDir_Files(t *testing.T) {
 	t.Run("by default should return empty slice", func(t *testing.T) {
-		dir := &fake.Dir{}
+		dir := fake.ExistingDir()
 		assert.Empty(t, dir.Files())
 	})
 }
 
 func TestFile_Close(t *testing.T) {
 	t.Run("should create empty file", func(t *testing.T) {
-		dir := &fake.Dir{}
+		dir := fake.ExistingDir()
 		file, _ := dir.FileWriter(fileName)
 		// when
 		err := file.Close()
@@ -55,7 +63,7 @@ func TestFile_Close(t *testing.T) {
 	})
 
 	t.Run("should write file", func(t *testing.T) {
-		dir := &fake.Dir{}
+		dir := fake.ExistingDir()
 		file, _ := dir.FileWriter(fileName)
 		data := []byte("payload")
 		_, err := file.Write(data)
@@ -77,7 +85,7 @@ func TestFile_Write(t *testing.T) {
 func TestFile_Sync(t *testing.T) {
 	t.Run("Sync should update SyncedData", func(t *testing.T) {
 		var (
-			dir     = &fake.Dir{}
+			dir     = fake.ExistingDir()
 			file, _ = dir.FileWriter(fileName)
 			data    = []byte("payload")
 			_, _    = file.Write(data)
@@ -95,7 +103,7 @@ func TestFile_Sync(t *testing.T) {
 func TestFile_SyncedData(t *testing.T) {
 	t.Run("should return empty for not synced file", func(t *testing.T) {
 		var (
-			dir     = &fake.Dir{}
+			dir     = fake.ExistingDir()
 			file, _ = dir.FileWriter(fileName)
 			data    = []byte("payload")
 			_, _    = file.Write(data)

--- a/os.go
+++ b/os.go
@@ -37,8 +37,8 @@ func (o OsDir) Exists() (bool, error) {
 	return f.IsDir(), nil
 }
 
-func (o OsDir) Mkdir(name string) error {
-	err := os.Mkdir(o.path(name), 0775)
+func (o OsDir) Mkdir() error {
+	err := os.Mkdir(string(o), 0775)
 	if os.IsExist(err) {
 		return nil
 	}

--- a/os.go
+++ b/os.go
@@ -29,8 +29,8 @@ func (o OsDir) path(name string) string {
 	return filepath.Join(string(o), name)
 }
 
-func (o OsDir) DirExists(name string) (bool, error) {
-	f, err := os.Stat(o.path(name))
+func (o OsDir) Exists() (bool, error) {
+	f, err := os.Stat(string(o))
 	if os.IsNotExist(err) {
 		return false, nil
 	}

--- a/os_test.go
+++ b/os_test.go
@@ -2,6 +2,7 @@ package deebee_test
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/jacekolszak/deebee"
@@ -10,16 +11,27 @@ import (
 )
 
 var dirs = map[string]test.NewDir{
-	"root":   rootDir,
-	"nested": makeNestedDir,
+	"existing root": existingRootDir,
+	"created root":  makeRootDir,
+	"nested":        makeNestedDir,
 }
 
-func rootDir(t *testing.T) deebee.Dir {
+func existingRootDir(t *testing.T) deebee.Dir {
 	return deebee.OsDir(createTempDir(t))
 }
 
+func makeRootDir(t *testing.T) deebee.Dir {
+	dir := createTempDir(t)
+	err := os.RemoveAll(dir)
+	require.NoError(t, err)
+	missing := deebee.OsDir(dir)
+	err = missing.Mkdir()
+	require.NoError(t, err)
+	return missing
+}
+
 func makeNestedDir(t *testing.T) deebee.Dir {
-	dir := rootDir(t)
+	dir := existingRootDir(t)
 	err := dir.Dir("nested").Mkdir()
 	require.NoError(t, err)
 	return dir.Dir("nested")

--- a/os_test.go
+++ b/os_test.go
@@ -41,8 +41,8 @@ func TestFileReader_Read(t *testing.T) {
 	test.TestFileReader_Read(t, dirs)
 }
 
-func TestOsDir_DirExists(t *testing.T) {
-	test.TestDir_DirExists(t, dirs)
+func TestOsDir_Exists(t *testing.T) {
+	test.TestDir_Exists(t, dirs)
 }
 
 func TestOsDir_Mkdir(t *testing.T) {

--- a/os_test.go
+++ b/os_test.go
@@ -20,7 +20,7 @@ func rootDir(t *testing.T) deebee.Dir {
 
 func makeNestedDir(t *testing.T) deebee.Dir {
 	dir := rootDir(t)
-	err := dir.Mkdir("nested")
+	err := dir.Dir("nested").Mkdir()
 	require.NoError(t, err)
 	return dir.Dir("nested")
 }

--- a/reader.go
+++ b/reader.go
@@ -8,20 +8,21 @@ type openReader func(key string) (io.ReadCloser, error)
 
 func openReaderFunc(dir Dir, newChecksum NewChecksum) openReader {
 	return func(key string) (io.ReadCloser, error) {
-		dirExists, err := dir.DirExists(key)
+		dataDir := dir.Dir(key)
+		dataDirExists, err := dataDir.Exists()
 		if err != nil {
 			return nil, err
 		}
-		if !dirExists {
+		if !dataDirExists {
 			return nil, &dataNotFoundError{}
 		}
-		files, err := dir.Dir(key).ListFiles()
+		files, err := dataDir.ListFiles()
 		if err != nil {
 			return nil, err
 		}
 		if len(files) == 0 {
 			return nil, &dataNotFoundError{}
 		}
-		return dir.Dir(key).FileReader("data")
+		return dataDir.FileReader("data")
 	}
 }

--- a/test/filesystem.go
+++ b/test/filesystem.go
@@ -158,13 +158,13 @@ func TestFileReader_Read(t *testing.T, dirs Dirs) {
 	}
 }
 
-func TestDir_DirExists(t *testing.T, dirs Dirs) {
+func TestDir_Exists(t *testing.T, dirs Dirs) {
 	for dirType, newDir := range dirs {
 		t.Run(dirType, func(t *testing.T) {
 
 			t.Run("should return false for not existing dir", func(t *testing.T) {
 				dir := newDir(t)
-				exists, err := dir.DirExists("not-existing")
+				exists, err := dir.Dir("not-existing").Exists()
 				require.NoError(t, err)
 				assert.False(t, exists)
 			})
@@ -174,7 +174,7 @@ func TestDir_DirExists(t *testing.T, dirs Dirs) {
 				err := dir.Mkdir("existing")
 				require.NoError(t, err)
 				// when
-				exists, err := dir.DirExists("existing")
+				exists, err := dir.Dir("existing").Exists()
 				require.NoError(t, err)
 				assert.True(t, exists)
 			})
@@ -183,7 +183,7 @@ func TestDir_DirExists(t *testing.T, dirs Dirs) {
 				dir := newDir(t)
 				notExisting := dir.Dir("not-existing")
 				// when
-				exists, err := notExisting.DirExists("another")
+				exists, err := notExisting.Dir("another").Exists()
 				require.NoError(t, err)
 				assert.False(t, exists)
 			})

--- a/test/filesystem.go
+++ b/test/filesystem.go
@@ -36,7 +36,7 @@ func ReadFile(t *testing.T, dir deebee.Dir, name string) []byte {
 }
 
 func Mkdir(t *testing.T, dir deebee.Dir, name string) deebee.Dir {
-	err := dir.Mkdir(name)
+	err := dir.Dir(name).Mkdir()
 	require.NoError(t, err)
 	return dir.Dir(name)
 }
@@ -92,7 +92,7 @@ func TestDir_FileReader(t *testing.T, dirs Dirs) {
 				assert.Nil(t, file)
 			})
 
-			t.Run("should return error when file does not exist", func(t *testing.T) {
+			t.Run("should return error when file is missing", func(t *testing.T) {
 				file, err := newDir(t).FileReader(fileName)
 				require.Error(t, err)
 				assert.Nil(t, file)
@@ -162,16 +162,16 @@ func TestDir_Exists(t *testing.T, dirs Dirs) {
 	for dirType, newDir := range dirs {
 		t.Run(dirType, func(t *testing.T) {
 
-			t.Run("should return false for not existing dir", func(t *testing.T) {
+			t.Run("should return false for missing dir", func(t *testing.T) {
 				dir := newDir(t)
-				exists, err := dir.Dir("not-existing").Exists()
+				exists, err := dir.Dir("missing").Exists()
 				require.NoError(t, err)
 				assert.False(t, exists)
 			})
 
 			t.Run("should return true for previously created dir", func(t *testing.T) {
 				dir := newDir(t)
-				err := dir.Mkdir("existing")
+				err := dir.Dir("existing").Mkdir()
 				require.NoError(t, err)
 				// when
 				exists, err := dir.Dir("existing").Exists()
@@ -179,11 +179,11 @@ func TestDir_Exists(t *testing.T, dirs Dirs) {
 				assert.True(t, exists)
 			})
 
-			t.Run("should return false when parent does not exist", func(t *testing.T) {
+			t.Run("should return false when parent dir is missing", func(t *testing.T) {
 				dir := newDir(t)
-				notExisting := dir.Dir("not-existing")
+				missing := dir.Dir("missing")
 				// when
-				exists, err := notExisting.Dir("another").Exists()
+				exists, err := missing.Dir("another").Exists()
 				require.NoError(t, err)
 				assert.False(t, exists)
 			})
@@ -197,17 +197,17 @@ func TestDir_Mkdir(t *testing.T, dirs Dirs) {
 
 			t.Run("should allow creating dir twice", func(t *testing.T) {
 				dir := newDir(t)
-				err := dir.Mkdir("name")
+				err := dir.Dir("name").Mkdir()
 				require.NoError(t, err)
-				err = dir.Mkdir("name")
+				err = dir.Dir("name").Mkdir()
 				require.NoError(t, err)
 			})
 
-			t.Run("should return error when dir does not exists", func(t *testing.T) {
+			t.Run("should return error when parent dir is missing", func(t *testing.T) {
 				dir := newDir(t)
-				notExistingDir := dir.Dir("not-existing-dir")
+				missingDir := dir.Dir("missing")
 				// when
-				err := notExistingDir.Mkdir("another")
+				err := missingDir.Dir("another").Mkdir()
 				// then
 				require.Error(t, err)
 			})
@@ -263,11 +263,11 @@ func TestDir_ListFiles(t *testing.T, dirs Dirs) {
 				assert.Contains(t, files, "name2")
 			})
 
-			t.Run("should return error when dir does not exists", func(t *testing.T) {
+			t.Run("should return error when dir is missing", func(t *testing.T) {
 				dir := newDir(t)
-				notExistingDir := dir.Dir("not-existing-dir")
+				missingDir := dir.Dir("missing")
 				// when
-				files, err := notExistingDir.ListFiles()
+				files, err := missingDir.ListFiles()
 				// then
 				require.Error(t, err)
 				assert.Nil(t, files)
@@ -275,7 +275,7 @@ func TestDir_ListFiles(t *testing.T, dirs Dirs) {
 
 			t.Run("should return files only", func(t *testing.T) {
 				dir := newDir(t)
-				err := dir.Mkdir("excludedDir")
+				err := dir.Dir("excludedDir").Mkdir()
 				require.NoError(t, err)
 				// when
 				files, err := dir.ListFiles()
@@ -286,7 +286,7 @@ func TestDir_ListFiles(t *testing.T, dirs Dirs) {
 
 			t.Run("should write and read file using different Dir instances", func(t *testing.T) {
 				dir := newDir(t)
-				err := dir.Mkdir("nested")
+				err := dir.Dir("nested").Mkdir()
 				require.NoError(t, err)
 				dir1 := dir.Dir("nested")
 				data := []byte("Hello")

--- a/writer.go
+++ b/writer.go
@@ -8,15 +8,16 @@ type openWriter func(key string) (io.WriteCloser, error)
 
 func openWriterFunc(dir Dir, newChecksum NewChecksum) openWriter {
 	return func(key string) (io.WriteCloser, error) {
-		exists, err := dir.DirExists(key)
+		dataDir := dir.Dir(key)
+		dataDirExists, err := dataDir.Exists()
 		if err != nil {
 			return nil, err
 		}
-		if !exists {
+		if !dataDirExists {
 			if err := dir.Mkdir(key); err != nil {
 				return nil, err
 			}
 		}
-		return dir.Dir(key).FileWriter("data")
+		return dataDir.FileWriter("data")
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -14,7 +14,7 @@ func openWriterFunc(dir Dir, newChecksum NewChecksum) openWriter {
 			return nil, err
 		}
 		if !dataDirExists {
-			if err := dir.Mkdir(key); err != nil {
+			if err := dataDir.Mkdir(); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Refactor DirExists(name) to be parameter-less. Such method will be more reusable - code can check existence of both database dir and nested directories.