### PR TITLE
Add State#Versions for Compacter

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -91,7 +91,8 @@ func lazyLatestIntegralFilename(dir Dir, algorithm ChecksumAlgorithm) (string, e
 	if err != nil {
 		return "", err
 	}
-	dataFiles := sortByVersionDescending(filterDatafiles(files))
+	dataFiles := filterDatafiles(files)
+	sortByVersionDescending(dataFiles)
 	if len(dataFiles) == 0 {
 		return "", &dataNotFoundError{}
 	}

--- a/compacter.go
+++ b/compacter.go
@@ -17,14 +17,23 @@ type State interface {
 	// Updates returns channel informing Compacter that state was updated. If compacter can't keep up, then some updates
 	// might be discarded.
 	Updates() <-chan struct{}
+	Versions() ([]StateVersion, error)
+}
+
+type StateVersion struct {
+	Revision int
 }
 
 type state struct {
+	dir     Dir
 	updates chan struct{}
 }
 
-func openState() *state {
-	return &state{updates: make(chan struct{}, 1)}
+func openState(dir Dir) *state {
+	return &state{
+		dir:     dir,
+		updates: make(chan struct{}, 1),
+	}
 }
 
 func (s *state) close() {
@@ -33,6 +42,23 @@ func (s *state) close() {
 
 func (s *state) Updates() <-chan struct{} {
 	return s.updates
+}
+
+func (s *state) Versions() ([]StateVersion, error) {
+	files, err := s.dir.ListFiles()
+	if err != nil {
+		return nil, err
+	}
+	dataFiles := filterDatafiles(files)
+	sortByVersionAscending(dataFiles)
+	var states []StateVersion
+	for _, datafile := range dataFiles {
+		version := StateVersion{
+			Revision: datafile.version,
+		}
+		states = append(states, version)
+	}
+	return states, nil
 }
 
 func (s *state) notifyUpdated() {

--- a/deebee.go
+++ b/deebee.go
@@ -21,7 +21,7 @@ func Open(dir Dir, options ...Option) (*DB, error) {
 
 	db := &DB{
 		dir:   dir,
-		state: openState(),
+		state: openState(dir),
 	}
 
 	for _, apply := range options {

--- a/filename.go
+++ b/filename.go
@@ -65,7 +65,10 @@ func (f filenames) youngestFilename() (filename, bool) {
 	return youngest, true
 }
 
-func sortByVersionDescending(f filenames) filenames {
+func sortByVersionDescending(f filenames) {
 	sort.Sort(f)
-	return f
+}
+
+func sortByVersionAscending(f filenames) {
+	sort.Sort(sort.Reverse(f))
 }


### PR DESCRIPTION
This function can be executed by Compacter in order to figure out what versions are saved on disk. Based on that informaction Compacter can decide to remove a state.