### PR TITLE
Use original checksum algorithm when reading

### DIFF
--- a/checksum/algorithms.go
+++ b/checksum/algorithms.go
@@ -16,7 +16,7 @@ var CRC64 = &algorithm{
 			Hash: crc64.New(table),
 		}
 	},
-	name: "crc64",
+	name: algorithmName("crc64"),
 }
 
 var CRC32 = &algorithm{
@@ -25,7 +25,7 @@ var CRC32 = &algorithm{
 			Hash: crc32.New(crc32.IEEETable),
 		}
 	},
-	name: "crc32",
+	name: algorithmName("crc32"),
 }
 
 var SHA512 = &algorithm{
@@ -34,7 +34,7 @@ var SHA512 = &algorithm{
 			Hash: sha512.New(),
 		}
 	},
-	name: "sha512",
+	name: algorithmName("sha512"),
 }
 
 var MD5 = &algorithm{
@@ -43,7 +43,7 @@ var MD5 = &algorithm{
 			Hash: md5.New(),
 		}
 	},
-	name: "md5",
+	name: algorithmName("md5"),
 }
 
 var FNV32 = &algorithm{
@@ -52,7 +52,7 @@ var FNV32 = &algorithm{
 			Hash: fnv.New32(),
 		}
 	},
-	name: "fnv32",
+	name: algorithmName("fnv32"),
 }
 
 var FNV32a = &algorithm{
@@ -61,7 +61,7 @@ var FNV32a = &algorithm{
 			Hash: fnv.New32a(),
 		}
 	},
-	name: "fnv32a",
+	name: algorithmName("fnv32a"),
 }
 
 var FNV64 = &algorithm{
@@ -70,7 +70,7 @@ var FNV64 = &algorithm{
 			Hash: fnv.New64(),
 		}
 	},
-	name: "fnv64",
+	name: algorithmName("fnv64"),
 }
 
 var FNV64a = &algorithm{
@@ -79,7 +79,7 @@ var FNV64a = &algorithm{
 			Hash: fnv.New64a(),
 		}
 	},
-	name: "fnv64a",
+	name: algorithmName("fnv64a"),
 }
 
 var FNV128 = &algorithm{
@@ -88,7 +88,7 @@ var FNV128 = &algorithm{
 			Hash: fnv.New128(),
 		}
 	},
-	name: "fnv128",
+	name: algorithmName("fnv128"),
 }
 
 var FNV128a = &algorithm{
@@ -97,15 +97,15 @@ var FNV128a = &algorithm{
 			Hash: fnv.New128a(),
 		}
 	},
-	name: "fnv128a",
+	name: algorithmName("fnv128a"),
 }
 
 type algorithm struct {
 	newSum func() Sum
-	name   string
+	name   AlgorithmName
 }
 
-func (h *algorithm) Name() string {
+func (h *algorithm) Name() AlgorithmName {
 	return h.name
 }
 
@@ -119,4 +119,23 @@ type hashSum struct {
 
 func (f *hashSum) Marshal() []byte {
 	return f.Hash.Sum([]byte{})
+}
+
+func algorithmName(s string) AlgorithmName {
+	name := AlgorithmName{}
+	copy(name[:], s)
+	return name
+}
+
+var algorithmsByName = map[AlgorithmName]*algorithm{
+	MD5.Name():     MD5,
+	CRC64.Name():   CRC64,
+	CRC32.Name():   CRC32,
+	SHA512.Name():  SHA512,
+	FNV64a.Name():  FNV64a,
+	FNV64.Name():   FNV64,
+	FNV32.Name():   FNV32,
+	FNV32a.Name():  FNV32a,
+	FNV128.Name():  FNV128,
+	FNV128a.Name(): FNV128a,
 }

--- a/checksum/codec.go
+++ b/checksum/codec.go
@@ -1,0 +1,18 @@
+package checksum
+
+const nameLen = 8
+
+type AlgorithmName [nameLen]byte
+
+func encode(name AlgorithmName, sum []byte) []byte {
+	algoAndSum := make([]byte, nameLen+len(sum))
+	copy(algoAndSum, name[:])
+	copy(algoAndSum[nameLen:], sum)
+	return algoAndSum
+}
+
+func decode(algoAndSum []byte) (AlgorithmName, []byte) {
+	name := AlgorithmName{}
+	copy(name[:], algoAndSum[:nameLen])
+	return name, algoAndSum[nameLen:]
+}

--- a/dirtest/dirtest.go
+++ b/dirtest/dirtest.go
@@ -338,12 +338,6 @@ func TestDir_DeleteFile(t *testing.T, dirs Dirs) {
 	for dirType, newDir := range dirs {
 		t.Run(dirType, func(t *testing.T) {
 
-			t.Run("should return error when file does not exists", func(t *testing.T) {
-				dir := newDir(t)
-				err := dir.DeleteFile("missing")
-				assert.Error(t, err)
-			})
-
 			t.Run("should delete file", func(t *testing.T) {
 				dir := newDir(t)
 				const file = "file"
@@ -355,6 +349,12 @@ func TestDir_DeleteFile(t *testing.T, dirs Dirs) {
 				files, err := dir.ListFiles()
 				require.NoError(t, err)
 				assert.Empty(t, files)
+			})
+
+			t.Run("should not return error when file does not exists", func(t *testing.T) {
+				dir := newDir(t)
+				err := dir.DeleteFile("missing")
+				assert.NoError(t, err)
 			})
 		})
 	}

--- a/fake/dir.go
+++ b/fake/dir.go
@@ -165,7 +165,7 @@ func (f *dir) DeleteFile(name string) error {
 
 	_, found := f.filesByName[name]
 	if !found {
-		return fmt.Errorf("file %s does not exist", name)
+		return nil
 	}
 	delete(f.filesByName, name)
 	return nil

--- a/os/os.go
+++ b/os/os.go
@@ -66,5 +66,9 @@ func (o Dir) ListFiles() ([]string, error) {
 }
 
 func (o Dir) DeleteFile(name string) error {
-	return os.Remove(o.path(name))
+	err := os.Remove(o.path(name))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }

--- a/store/compacter.go
+++ b/store/compacter.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -73,7 +74,13 @@ type stateVersion struct {
 }
 
 func (s *stateVersion) Remove() error {
-	return s.dir.DeleteFile(s.dataFile.name)
+	if err := s.dir.DeleteFile(s.dataFile.name); err != nil {
+		return fmt.Errorf("deleting data file failed: %w", err)
+	}
+	if err := s.dir.DeleteFile(checksumFilename(s.dataFile.name)); err != nil {
+		return fmt.Errorf("deleting checksum file failed: %w", err)
+	}
+	return nil
 }
 
 func (s *stateVersion) Revision() int {

--- a/store/dir.go
+++ b/store/dir.go
@@ -18,6 +18,7 @@ type Dir interface {
 	Exists() (bool, error)
 	// ListFiles list files excluding directories
 	ListFiles() ([]string, error)
+	// DeleteFile does not return error when file does not exist
 	DeleteFile(name string) error
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -221,8 +221,8 @@ func TestIntegrityChecker(t *testing.T) {
 
 type failingIntegrityChecker struct{}
 
-func (f failingIntegrityChecker) DecorateReader(reader io.ReadCloser, readChecksum store.ReadChecksum) io.ReadCloser {
-	return &failingReader{ReadCloser: reader}
+func (f failingIntegrityChecker) DecorateReader(reader io.ReadCloser, readChecksum store.ReadChecksum) (io.ReadCloser, error) {
+	return &failingReader{ReadCloser: reader}, nil
 }
 
 type failingReader struct {
@@ -233,8 +233,8 @@ func (f failingReader) Close() error {
 	return errors.New("error")
 }
 
-func (f failingIntegrityChecker) DecorateWriter(writer io.WriteCloser, writeChecksum store.WriteChecksum) io.WriteCloser {
-	return writer
+func (f failingIntegrityChecker) DecorateWriter(writer io.WriteCloser, writeChecksum store.WriteChecksum) (io.WriteCloser, error) {
+	return writer, nil
 }
 
 func openStore(t *testing.T, dir store.Dir) *store.Store {


### PR DESCRIPTION
Checksum algorithm can be changed when opening a store on an existing dir. In such case during read the original algorithm used for writing should be used.