### PR TITLE
Fix compaction.KeepLatestVersions

### DIFF
--- a/compaction/compaction.go
+++ b/compaction/compaction.go
@@ -127,6 +127,9 @@ func KeepLatestVersions(min int) StrategyOption {
 			return fmt.Errorf("negative max in compaction.MinVersions: %d", min)
 		}
 		policy := func(versions []store.StateVersion) []store.StateVersion {
+			if len(versions) < min {
+				return versions
+			}
 			return versions[len(versions)-min:]
 		}
 		compacter.keepPolicies = append(compacter.keepPolicies, policy)

--- a/compaction/compaction_test.go
+++ b/compaction/compaction_test.go
@@ -382,4 +382,17 @@ func TestKeepLatestVersions(t *testing.T) {
 		// then
 		assert.Eventually(t, stateRevisionsAre(state, 2, 3), time.Second, time.Millisecond)
 	})
+
+	t.Run("should keep one latest version when there is only one available but two were requested", func(t *testing.T) {
+		compacter, err :=
+			compaction.NewCompacter(
+				compaction.KeepLatestVersions(2),
+				compaction.Interval(time.Microsecond))
+		state := &fake.State{}
+		startCompacterAsynchronously(t, compacter, state)
+		require.NoError(t, err)
+		state.AddVersion(1)
+		// then
+		assert.Eventually(t, stateRevisionsAre(state, 1), time.Second, time.Millisecond)
+	})
 }


### PR DESCRIPTION
When number of available versions is lower than minimum requested panic is raised.