### PR TITLE
Change deebee.Open signature

### DIFF
--- a/deebee.go
+++ b/deebee.go
@@ -3,14 +3,15 @@ package deebee
 import (
 	"github.com/jacekolszak/deebee/checksum"
 	"github.com/jacekolszak/deebee/compaction"
+	"github.com/jacekolszak/deebee/os"
 	"github.com/jacekolszak/deebee/store"
 )
 
-func Open(dir store.Dir, options ...store.Option) (*store.Store, error) {
+func Open(dir string, options ...store.Option) (*store.Store, error) {
 	defaultOptions := []store.Option{
 		checksum.IntegrityChecker(),
 		compaction.Strategy(compaction.MaxVersions(2)),
 	}
 	mergedOptions := append(defaultOptions, options...)
-	return store.Open(dir, mergedOptions...)
+	return store.Open(os.Dir(dir), mergedOptions...)
 }

--- a/example/checksum/main.go
+++ b/example/checksum/main.go
@@ -5,14 +5,11 @@ import (
 
 	"github.com/jacekolszak/deebee"
 	"github.com/jacekolszak/deebee/checksum"
-	"github.com/jacekolszak/deebee/os"
 )
 
 // This program shows how to configure different checksum algorithm.
 func main() {
-	dir := os.Dir(tempDir())
-
-	s, err := deebee.Open(dir,
+	s, err := deebee.Open(tempDir(),
 		checksum.IntegrityChecker(
 			checksum.Algorithm(checksum.FNV128a),
 		),

--- a/example/compaction/main.go
+++ b/example/compaction/main.go
@@ -5,14 +5,11 @@ import (
 
 	"github.com/jacekolszak/deebee"
 	"github.com/jacekolszak/deebee/compaction"
-	"github.com/jacekolszak/deebee/os"
 )
 
 // This program shows how to change compaction strategy.
 func main() {
-	dir := os.Dir(tempDir())
-
-	s, err := deebee.Open(dir,
+	s, err := deebee.Open(tempDir(),
 		compaction.Strategy(
 			compaction.KeepLatestVersions(2),
 			compaction.MaxVersions(10),

--- a/example/main.go
+++ b/example/main.go
@@ -5,12 +5,11 @@ import (
 	"io/ioutil"
 
 	"github.com/jacekolszak/deebee"
-	"github.com/jacekolszak/deebee/os"
 	"github.com/jacekolszak/deebee/store"
 )
 
 func main() {
-	dir := os.Dir(tempDir())
+	dir := tempDir()
 	fmt.Println("Store directory:", dir)
 
 	s, err := deebee.Open(dir)


### PR DESCRIPTION
deebee.Open now requires passing store.Dir implementation. This can be too complicated for newcomers. Dir can be changed to string. This change will not change store package which will still allow to pass different Dir instances.