### PR TITLE
Store.Close() should wait for compacter to finish

### DIFF
--- a/compaction/compaction.go
+++ b/compaction/compaction.go
@@ -15,10 +15,7 @@ func Strategy(options ...StrategyOption) store.Option {
 		if err != nil {
 			return fmt.Errorf("NewCompacter failed: %w", err)
 		}
-		compactState := func(ctx context.Context, state store.State) {
-			go compacter.Start(ctx, state)
-		}
-		return store.Compacter(compactState)(s)
+		return store.Compacter(compacter.Start)(s)
 	}
 }
 


### PR DESCRIPTION
When the whole program finishes before compacter, some potential garbage could be left (for example data file could be removed, but checksum file could be left).

Fixes #41