### PR TITLE
Make Decoder and Encoder more generic

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -5,6 +5,7 @@ package codec
 
 import (
 	"errors"
+	"io"
 
 	"github.com/jacekolszak/deebee/store"
 )
@@ -29,7 +30,7 @@ func Read(s ReadOnlyStore, decoder Decoder, options ...store.ReaderOption) (stor
 	return reader.Version(), nil
 }
 
-type Decoder func(reader store.Reader) error
+type Decoder func(reader io.Reader) error
 
 func Write(s WriteOnlyStore, encoder Encoder, options ...store.WriterOption) error {
 	if encoder == nil {
@@ -47,7 +48,7 @@ func Write(s WriteOnlyStore, encoder Encoder, options ...store.WriterOption) err
 	return writer.Close()
 }
 
-type Encoder func(writer store.Writer) error
+type Encoder func(writer io.Writer) error
 
 // ReadLatest reads latest version or fallback to previous one when decoder returned error
 func ReadLatest(s ReadOnlyStore, decoder Decoder) (store.Version, error) {

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -5,6 +5,7 @@ package codec_test
 
 import (
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/jacekolszak/deebee/codec"
@@ -25,7 +26,7 @@ func TestWrite(t *testing.T) {
 	t.Run("should write using encoder", func(t *testing.T) {
 		s := tests.OpenStore(t)
 		input := []byte("data")
-		encoder := func(w store.Writer) error {
+		encoder := func(w io.Writer) error {
 			_, e := w.Write(input)
 			return e
 		}
@@ -39,7 +40,7 @@ func TestWrite(t *testing.T) {
 
 	t.Run("should abort writing on encoding error", func(t *testing.T) {
 		s := tests.OpenStore(t)
-		encoder := func(store.Writer) error {
+		encoder := func(io.Writer) error {
 			return errors.New("failed")
 		}
 		// when
@@ -90,7 +91,7 @@ func TestReadLatest(t *testing.T) {
 		})
 
 		t.Run("when no store is given", func(t *testing.T) {
-			decoder := func(reader store.Reader) error {
+			decoder := func(reader io.Reader) error {
 				return nil
 			}
 			_, err := codec.ReadLatest(nil, decoder)
@@ -196,6 +197,6 @@ func TestReadLatest(t *testing.T) {
 	})
 }
 
-func failingDecoder(store.Reader) error {
+func failingDecoder(io.Reader) error {
 	return errors.New("decoder failed")
 }

--- a/compacter/compacter.go
+++ b/compacter/compacter.go
@@ -105,7 +105,7 @@ func applyOptions(options []Option) (*Options, error) {
 	return opts, nil
 }
 
-func readAllDiscarding(reader store.Reader) error {
+func readAllDiscarding(reader io.Reader) error {
 	block := make([]byte, 512)
 	for {
 		_, err := reader.Read(block)

--- a/example/codec/read/main.go
+++ b/example/codec/read/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 
 	"github.com/jacekolszak/deebee/codec"
@@ -16,7 +17,7 @@ func main() {
 	}
 
 	var bytesRead []byte
-	version, err := codec.Read(s, func(reader store.Reader) error {
+	version, err := codec.Read(s, func(reader io.Reader) error {
 		all, e := ioutil.ReadAll(reader)
 		if e != nil {
 			return e

--- a/example/codec/write/main.go
+++ b/example/codec/write/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io"
+
 	"github.com/jacekolszak/deebee/codec"
 	"github.com/jacekolszak/deebee/store"
 )
@@ -13,7 +15,7 @@ func main() {
 	}
 
 	bytes := []byte("Written using encoder")
-	err = codec.Write(s, func(writer store.Writer) error {
+	err = codec.Write(s, func(writer io.Writer) error {
 		_, e := writer.Write(bytes)
 		return e
 	})

--- a/internal/tests/codec.go
+++ b/internal/tests/codec.go
@@ -5,15 +5,13 @@ package tests
 
 import (
 	"io"
-
-	"github.com/jacekolszak/deebee/store"
 )
 
 type FakeDecoder struct {
 	dataRead []byte
 }
 
-func (f *FakeDecoder) Decode(reader store.Reader) error {
+func (f *FakeDecoder) Decode(reader io.Reader) error {
 	data, err := io.ReadAll(reader)
 	if err != nil {
 		return err

--- a/json/json.go
+++ b/json/json.go
@@ -5,6 +5,7 @@ package json
 
 import (
 	"encoding/json"
+	"io"
 
 	"github.com/jacekolszak/deebee/codec"
 	"github.com/jacekolszak/deebee/store"
@@ -14,8 +15,8 @@ func Read(s codec.ReadOnlyStore, out interface{}, options ...store.ReaderOption)
 	return codec.Read(s, Decoder(out), options...)
 }
 
-func Decoder(out interface{}) func(reader store.Reader) error {
-	return func(reader store.Reader) error {
+func Decoder(out interface{}) func(reader io.Reader) error {
+	return func(reader io.Reader) error {
 		return json.NewDecoder(reader).Decode(out)
 	}
 }
@@ -24,8 +25,8 @@ func Write(s codec.WriteOnlyStore, in interface{}, options ...store.WriterOption
 	return codec.Write(s, Encoder(in), options...)
 }
 
-func Encoder(in interface{}) func(writer store.Writer) error {
-	return func(writer store.Writer) error {
+func Encoder(in interface{}) func(writer io.Writer) error {
+	return func(writer io.Writer) error {
 		return json.NewEncoder(writer).Encode(in)
 	}
 }

--- a/replicator/replicator_test.go
+++ b/replicator/replicator_test.go
@@ -6,6 +6,7 @@ package replicator_test
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -143,7 +144,7 @@ func TestStartFromTo(t *testing.T) {
 func TestReadLatest(t *testing.T) {
 	t.Run("should return error", func(t *testing.T) {
 		t.Run("when no store is given", func(t *testing.T) {
-			decoder := func(reader store.Reader) error {
+			decoder := func(reader io.Reader) error {
 				return nil
 			}
 			_, err := replicator.ReadLatest(decoder)
@@ -157,7 +158,7 @@ func TestReadLatest(t *testing.T) {
 		})
 
 		t.Run("nil stores", func(t *testing.T) {
-			decoder := func(reader store.Reader) error {
+			decoder := func(reader io.Reader) error {
 				return nil
 			}
 			_, err := replicator.ReadLatest(decoder, nil, nil)
@@ -273,7 +274,7 @@ func TestReadLatest(t *testing.T) {
 	})
 }
 
-func failingDecoder(store.Reader) error {
+func failingDecoder(io.Reader) error {
 	return errors.New("decoder failed")
 }
 


### PR DESCRIPTION
These types should take io.Reader and io.Writer arguments instead of more specific store.Reader and store.Writer. There are 2 reasons:

* greater reusability
* it does not make much sense to close the reader/writer inside codec.