### PR TITLE
Add store option to disable integrity check

### DIFF
--- a/internal/tests/file.go
+++ b/internal/tests/file.go
@@ -1,0 +1,22 @@
+package tests
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func UpdateFiles(t *testing.T, dir, extension string, newContent string) {
+	files, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range files {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), extension) {
+			err := ioutil.WriteFile(path.Join(dir, e.Name()), []byte(newContent), 0644)
+			require.NoError(t, err)
+		}
+	}
+}

--- a/internal/tests/file.go
+++ b/internal/tests/file.go
@@ -20,3 +20,8 @@ func UpdateFiles(t *testing.T, dir, extension string, newContent string) {
 		}
 	}
 }
+
+func TouchFile(t *testing.T, path string) {
+	err := ioutil.WriteFile(path, []byte{}, 0664)
+	require.NoError(t, err)
+}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -6,7 +6,6 @@ package store_test
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"path"
 	"testing"
 
@@ -26,7 +25,7 @@ func TestOpen(t *testing.T) {
 
 	t.Run("should return error when dir is not a directory", func(t *testing.T) {
 		invalidDir := path.Join(tests.TempDir(t), "file")
-		touchFile(t, invalidDir)
+		tests.TouchFile(t, invalidDir)
 		// when
 		s, err := store.Open(invalidDir)
 		// then
@@ -195,11 +194,6 @@ func assertNotCorrupted(t *testing.T, reader store.Reader) {
 	err2 := reader.Close()
 	assert.NoError(t, err1)
 	assert.NoError(t, err2)
-}
-
-func touchFile(t *testing.T, path string) {
-	err := ioutil.WriteFile(path, []byte{}, 0664)
-	require.NoError(t, err)
 }
 
 func writeLargeData(t *testing.T, s *store.Store, blocks, blockSize int, writerOptions ...store.WriterOption) store.Version {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -26,7 +25,7 @@ func TestOpen(t *testing.T) {
 	})
 
 	t.Run("should return error when dir is not a directory", func(t *testing.T) {
-		invalidDir := path.Join(tempDir(t), "file")
+		invalidDir := path.Join(tests.TempDir(t), "file")
 		touchFile(t, invalidDir)
 		// when
 		s, err := store.Open(invalidDir)
@@ -36,28 +35,28 @@ func TestOpen(t *testing.T) {
 	})
 
 	t.Run("by default should create dir if does not exist", func(t *testing.T) {
-		dir := path.Join(tempDir(t), "missing")
+		dir := path.Join(tests.TempDir(t), "missing")
 		_, err := store.Open(dir)
 		require.NoError(t, err)
 		assert.DirExists(t, dir)
 	})
 
 	t.Run("by default should create nested dir if does not exist", func(t *testing.T) {
-		dir := path.Join(tempDir(t), "nested", "missing")
+		dir := path.Join(tests.TempDir(t), "nested", "missing")
 		_, err := store.Open(dir)
 		require.NoError(t, err)
 		assert.DirExists(t, dir)
 	})
 
 	t.Run("should return error when dir does not exist and FailWhenMissingDir option was used", func(t *testing.T) {
-		dir := path.Join(tempDir(t), "missing")
+		dir := path.Join(tests.TempDir(t), "missing")
 		s, err := store.Open(dir, store.FailWhenMissingDir)
 		require.Error(t, err)
 		assert.Nil(t, s)
 	})
 
 	t.Run("should accept nil option", func(t *testing.T) {
-		s, err := store.Open(tempDir(t), nil)
+		s, err := store.Open(tests.TempDir(t), nil)
 		require.NoError(t, err)
 		assert.NotNil(t, s)
 	})
@@ -66,7 +65,7 @@ func TestOpen(t *testing.T) {
 		option := func(*store.Store) error {
 			return errors.New("error")
 		}
-		s, err := store.Open(tempDir(t), option)
+		s, err := store.Open(tests.TempDir(t), option)
 		assert.Error(t, err)
 		assert.Nil(t, s)
 	})
@@ -196,15 +195,6 @@ func assertNotCorrupted(t *testing.T, reader store.Reader) {
 	err2 := reader.Close()
 	assert.NoError(t, err1)
 	assert.NoError(t, err2)
-}
-
-func tempDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "deebee")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(dir))
-	})
-	return dir
 }
 
 func touchFile(t *testing.T, path string) {


### PR DESCRIPTION
This can be really useful for development purposes. Developer might edit data file directly using has editor of choice and load the edited version into the program.

Solves #64 